### PR TITLE
Reduce python startup time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .gitcredentials
+.vscode
 apikey
 kubeconfig*
 tmp

--- a/hydrate/cluster.py
+++ b/hydrate/cluster.py
@@ -1,5 +1,4 @@
 """Kubernetes Cluster API Class."""
-from kubernetes import client, config
 from .component import Component
 import re
 
@@ -22,9 +21,11 @@ class Cluster():
 
     def connect_to_cluster(self):
         """Connect to the cluster. Set API attributes."""
-        config.load_kube_config(self.kubeconfig)
-        self.apps_v1_api = client.AppsV1Api()
-        self.core_v1_api = client.CoreV1Api()
+        from kubernetes.config import load_kube_config
+        from kubernetes.client import AppsV1Api, CoreV1Api
+        load_kube_config(self.kubeconfig)
+        self.apps_v1_api = AppsV1Api()
+        self.core_v1_api = CoreV1Api()
 
     def get_components(self):
         """Query the cluster for components.

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -33,14 +33,15 @@ class TestCluster():
 
     def test_connect_to_cluster(self, mocker, cluster_connection):
         """Test the method connect_to_cluster."""
-        mock_config = mocker.patch("hydrate.cluster.config", autospec=True)
-        mock_client = mocker.patch("hydrate.cluster.client", autospec=True)
+        mock_load_config = mocker.patch("kubernetes.config.load_kube_config")
+        mock_AppsV1Api = mocker.patch("kubernetes.client.AppsV1Api")
+        mock_CoreV1Api = mocker.patch("kubernetes.client.CoreV1Api")
 
         cluster_connection.connect_to_cluster()
 
-        mock_config.load_kube_config.assert_called_once()
-        mock_client.AppsV1Api.assert_called_once()
-        mock_client.CoreV1Api.assert_called_once()
+        mock_load_config.assert_called_once()
+        mock_AppsV1Api.assert_called_once()
+        mock_CoreV1Api.assert_called_once()
 
     tst_namespaces = ["elasticsearch", "istio", "jaeger"]
     tst_deps = ["elasticsearch-dep", "istio-dep", "jaeger-dep"]


### PR DESCRIPTION
closes #1 

This bug was caused by the large time cost of importing the kubernetes API package.

#### What I did
I solved the problem by reducing the imported functions, as well as moving the import to inside of the "connect_to_cluster" function. 

#### How it works
Reducing the imported functions means there's less overhead work for python to do each time hydrate is run. Moving the imports inside of a function instead of at the top means they won't need to be loaded until the function is called, which allows for output to reach the terminal quicker.