### PR TITLE
Add comments to generated component.yaml

### DIFF
--- a/hydrate/__main__.py
+++ b/hydrate/__main__.py
@@ -3,9 +3,9 @@
 Functions:
     - main()
 """
-import argparse
 import os
-import sys
+from argparse import ArgumentParser
+from sys import stdout
 from pathlib import Path
 
 from .cluster import Cluster
@@ -35,7 +35,7 @@ def main(args):
     subcomponents, category_indeces = match_components(rc, cc)
 
     verbose_print("Creating Component object...")
-    my_component = Component(args.name, path="./manifests")
+    my_component = Component(args.name, source=None, method=None)
 
     verbose_print("Creating the list of subcomponents...")
     sub_list = []
@@ -50,7 +50,7 @@ def main(args):
     output_file = None
     if args.dry_run:
         verbose_print("Writing component.yaml to terminal...")
-        generate_HLD(my_component, sys.stdout, category_indeces)
+        generate_HLD(my_component, stdout, category_indeces)
 
     else:
         if args.output:
@@ -67,7 +67,7 @@ def main(args):
 
 def parse_args():
     """Parse command line arguments."""
-    parser = argparse.ArgumentParser(
+    parser = ArgumentParser(
         description='Generate a component.yaml file for your cluster.')
     parser.add_argument(
         'run',

--- a/hydrate/comments.py
+++ b/hydrate/comments.py
@@ -1,0 +1,18 @@
+"""Home of component.yaml comment constants."""
+
+
+TOP_LEVEL_COMMENT = '''Automatically generated using hydrate.
+Repository link: https://github.com/microsoft/hydrate
+Fabrikate Docs: https://github.com/Microsoft/fabrikate
+For private repositories, check the following:
+Authentication: https://github.com/microsoft/fabrikate/blob/master/docs/auth.md
+For more information on how components are structured, check the following:
+Component Model: https://github.com/microsoft/fabrikate/blob/master/docs/component.md'''  # noqa
+
+
+NO_MATCH_COMMENT = '''No Match Deployments
+In order to use these deployments with Fabrikate, follow the steps below.
+1. Populate the source (git repository link)
+2. Add a path field (path within the git repository) ex: "path: stable/"
+3. Specify helm for applications generated using a Helm chart ex: "type: helm"
+Otherwise, comment them out to prevent errors with Fabrikate generation.'''

--- a/hydrate/component.py
+++ b/hydrate/component.py
@@ -66,6 +66,14 @@ class Component():
                 delattr(self, key)
 
 
+NO_MATCH_STR = '''No Match Deployments
+In order to use these deployments with Fabrikate, follow the steps below.
+1. Populate the source (git repository link)
+2. Add a path field (path within the git repository) ex: "path: stable/"
+3. Specify helm for applications generated using a Helm chart ex: "type: helm"
+Otherwise, comment them out to prevent errors with Fabrikate generation.'''
+
+
 def match_components(repo_components, cluster_components):
     """Match cluster and repo components."""
     subcomponents = []
@@ -81,7 +89,7 @@ def match_components(repo_components, cluster_components):
 
     if fm_leftovers:
         subcomponents.extend(fm_leftovers)
-        category_indeces.append((len(full_matches), "No Match Deployments"))
+        category_indeces.append((len(full_matches), NO_MATCH_STR))
 
     return subcomponents, category_indeces
 

--- a/hydrate/component.py
+++ b/hydrate/component.py
@@ -1,6 +1,7 @@
 """Fabrikate Component Class Definition."""
 
 from copy import deepcopy
+from .comments import NO_MATCH_COMMENT
 
 
 class Component():
@@ -66,14 +67,6 @@ class Component():
                 delattr(self, key)
 
 
-NO_MATCH_STR = '''No Match Deployments
-In order to use these deployments with Fabrikate, follow the steps below.
-1. Populate the source (git repository link)
-2. Add a path field (path within the git repository) ex: "path: stable/"
-3. Specify helm for applications generated using a Helm chart ex: "type: helm"
-Otherwise, comment them out to prevent errors with Fabrikate generation.'''
-
-
 def match_components(repo_components, cluster_components):
     """Match cluster and repo components."""
     subcomponents = []
@@ -89,7 +82,7 @@ def match_components(repo_components, cluster_components):
 
     if fm_leftovers:
         subcomponents.extend(fm_leftovers)
-        category_indeces.append((len(full_matches), NO_MATCH_STR))
+        category_indeces.append((len(full_matches), NO_MATCH_COMMENT))
 
     return subcomponents, category_indeces
 

--- a/hydrate/hld.py
+++ b/hydrate/hld.py
@@ -5,6 +5,14 @@ yaml = YAML()
 
 OFFSET = 2
 
+TOP_LVL_COMMENT = '''Automatically generated using hydrate.
+Repository link: https://github.com/microsoft/hydrate
+Fabrikate Docs: https://github.com/Microsoft/fabrikate
+For private repositories, check the following:
+Authentication: https://github.com/microsoft/fabrikate/blob/master/docs/auth.md
+For more information on how components are structured, check the following:
+Component Model: https://github.com/microsoft/fabrikate/blob/master/docs/component.md''' # noqa
+
 
 def generate_HLD(component, output, comment_indeces=None):
     """Create HLD yaml file.
@@ -20,6 +28,7 @@ def generate_HLD(component, output, comment_indeces=None):
     d = component.asdict()
     if comment_indeces:
         d = CommentedMap(d)
+        d.yaml_set_start_comment(TOP_LVL_COMMENT)
         lst = CommentedSeq(d["subcomponents"])
         for idx, comment in comment_indeces:
             lst.yaml_set_comment_before_after_key(idx, comment, OFFSET)

--- a/hydrate/hld.py
+++ b/hydrate/hld.py
@@ -1,17 +1,10 @@
 """Use to construct the High-Level Deployment."""
+from .comments import TOP_LEVEL_COMMENT
 from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from ruamel.yaml import YAML
 yaml = YAML()
 
 OFFSET = 2
-
-TOP_LVL_COMMENT = '''Automatically generated using hydrate.
-Repository link: https://github.com/microsoft/hydrate
-Fabrikate Docs: https://github.com/Microsoft/fabrikate
-For private repositories, check the following:
-Authentication: https://github.com/microsoft/fabrikate/blob/master/docs/auth.md
-For more information on how components are structured, check the following:
-Component Model: https://github.com/microsoft/fabrikate/blob/master/docs/component.md''' # noqa
 
 
 def generate_HLD(component, output, comment_indeces=None):
@@ -28,7 +21,7 @@ def generate_HLD(component, output, comment_indeces=None):
     d = component.asdict()
     if comment_indeces:
         d = CommentedMap(d)
-        d.yaml_set_start_comment(TOP_LVL_COMMENT)
+        d.yaml_set_start_comment(TOP_LEVEL_COMMENT)
         lst = CommentedSeq(d["subcomponents"])
         for idx, comment in comment_indeces:
             lst.yaml_set_comment_before_after_key(idx, comment, OFFSET)


### PR DESCRIPTION
closes #2 

There are now comments in the generated component.yaml. They're easily changed, so I'm open to enhancements to the guidance. 

Here's what the top level comment looks like:
```yaml
# Automatically generated using hydrate.
# Repository link: https://github.com/microsoft/hydrate
# Fabrikate Docs: https://github.com/Microsoft/fabrikate
# For private repositories, check the following:
# Auththentication: https://github.com/microsoft/fabrikate/blob/master/docs/auth.md
# For more information on how components are structured, check the following:
# Component Model: https://github.com/microsoft/fabrikate/blob/master/docs/component.md
```

And the No match components comment:
```yaml
# No Match Deployments
# In order to use these deployments with Fabrikate, follow the steps below.
# 1. Populate the source (git repository link)
# 2. Add a path field (path within the git repository) ex: "path: stable/"
# 3. Specify helm for applications generated using a Helm chart ex: "type: helm"
# Otherwise, comment them out to prevent errors with Fabrikate generation.
```