### PR TITLE
Azure Pipelines: Increase pycodestyle character limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Hydrate
+[![Build Status](https://dev.azure.com/epicstuff/hydrate/_apis/build/status/microsoft.hydrate?branchName=master)](https://dev.azure.com/epicstuff/hydrate/_build/latest?definitionId=98&branchName=master)
+
 Hydrate crawls a kubernetes cluster and generates a high level description of your deployments.
 
 ## Setup

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ steps:
   displayName: 'Install dependencies'
 
 - script: |
-    pip install pytest 
+    pip install pytest
     pip install pytest-azurepipelines
     pip install pytest-cov
     pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
@@ -37,10 +37,10 @@ steps:
     pip install pycodestyle
     pip install pydocstyle
     pip install pyflakes
-    python -m pycodestyle hydrate/*.py
+    python -m pycodestyle --max-line-length 90 hydrate/*.py
     python -m pydocstyle hydrate/*.py
     python -m pyflakes hydrate/*.py
-    python -m pycodestyle tests/*.py
+    python -m pycodestyle --max-line-length 90 tests/*.py
     python -m pydocstyle tests/*.py
     python -m pyflakes tests/*.py
   displayName: 'CSE linting packages (pycodestyle, pydocstyle, pyflakes)'


### PR DESCRIPTION
Increase character limit from 80 to 90.

The reasoning behind this change comes from the arbitrary nature of an 80 character line limit in 2019, and the desire for ninety-ish character lines in Hydrate.
