### PR TITLE
(develop branch) Add manifests directory creation and generate namespaces.yaml

### DIFF
--- a/hydrate/hld.py
+++ b/hydrate/hld.py
@@ -3,6 +3,7 @@ from .comments import TOP_LEVEL_COMMENT
 from .cluster import Cluster
 from .component import TopComponent
 from .scrape import Scraper
+from .manifest import generate_manifests
 from .match import Matcher
 
 from sys import stdout
@@ -45,6 +46,8 @@ class HLD_Generator():
         match_categories = self._get_matches(cluster_components)
         # Step 3. Generate the HLD
         self._generate_HLD(match_categories)
+        # Step 4. Generate the manifests directory
+        self._generate_manifests()
 
     def _get_cluster_components(self):
         """Get objects living on the cluster."""
@@ -121,6 +124,11 @@ class HLD_Generator():
                                                         indent=OFFSET)
         data['subcomponents'] = temp_list
         return data
+
+    def _generate_manifests(self):
+        """Generate the manifests."""
+        namespaces = self.cluster.get_namespaces()
+        generate_manifests(namespaces)
 
     def dump_yaml(self, data, output):
         """Dump yaml to output."""

--- a/hydrate/manifest.py
+++ b/hydrate/manifest.py
@@ -1,6 +1,7 @@
 """Create manifest directory and populate it."""
 
 import os
+from io import StringIO
 from ruamel.yaml import YAML
 
 MAPPING = 2
@@ -27,7 +28,7 @@ class NamespaceYAML:
                 self.metadata == other.metadata)
 
 
-def generate_manifests(namespaces=None, directory="manifests"):
+def generate_manifests(namespaces=None, directory="manifests", dry_run=False):
     """Make and populate manifests directory.
 
     Creates the manifests directory if it doesn't already exist, and populates
@@ -39,13 +40,21 @@ def generate_manifests(namespaces=None, directory="manifests"):
         directory: string path (default:'manifests')
 
     """
-    _make_directory(directory)
-
     if namespaces:
-        namespaces_file = os.path.join(directory, "namespaces.yaml")
         data = _create_namespaces_data(namespaces)
-        with open(namespaces_file, 'w') as of:
+        if not dry_run:
+            _make_directory(directory)
+            namespaces_file = os.path.join(directory, "namespaces.yaml")
+            with open(namespaces_file, 'w') as of:
+                _generate_namespaces_yaml(data, of)
+        else:
+            print("Dry Run: namespaces.yaml:")
+            of = StringIO()
             _generate_namespaces_yaml(data, of)
+            of.seek(0)
+            print(of.read())
+    else:
+        raise Exception("Namespaces are None")
 
 
 def _make_directory(path):

--- a/hydrate/manifest.py
+++ b/hydrate/manifest.py
@@ -1,0 +1,84 @@
+"""Create manifest directory and populate it."""
+
+import os
+from ruamel.yaml import YAML
+
+MAPPING = 2
+SEQUENCE = 4
+OFFSET = 2
+
+
+class NamespaceYAML:
+    """Structure of namespace.yaml entries."""
+
+    def __init__(self, namespace):
+        """Instantiate NamespaceYAML object."""
+        self.apiVersion = "v1"
+        self.kind = "Namespace"
+        self.metadata = {"name": namespace}
+
+    def __eq__(self, other):
+        """Define equals operator between NamespaceYAML objects."""
+        if not isinstance(other, NamespaceYAML):
+            return NotImplemented
+
+        return (self.apiVersion == other.apiVersion and
+                self.kind == other.kind and
+                self.metadata == other.metadata)
+
+
+def generate_manifests(namespaces=None, directory="manifests"):
+    """Make and populate manifests directory.
+
+    Creates the manifests directory if it doesn't already exist, and populates
+    it with the following yaml files:
+        - namespaces.yaml
+
+    Args:
+        namespaces: list of strings (default: None)
+        directory: string path (default:'manifests')
+
+    """
+    _make_directory(directory)
+
+    if namespaces:
+        namespaces_file = os.path.join(directory, "namespaces.yaml")
+        data = _create_namespaces_data(namespaces)
+        with open(namespaces_file, 'w') as of:
+            _generate_namespaces_yaml(data, of)
+
+
+def _make_directory(path):
+    """Make directory, or do nothing if it already exists.
+
+    Args:
+        path: string
+
+    """
+    os.makedirs(path, exist_ok=True)
+
+
+def _create_namespaces_data(namespaces):
+    """Structure namespaces into namespace.yaml data.
+
+    Args:
+        namespaces: list of namespace strings
+
+    """
+    return [NamespaceYAML(namespace) for namespace in namespaces]
+
+
+def _generate_namespaces_yaml(namespace_yamls, outfile):
+    """Generate namespaces.yaml file from namespace_yamls data.
+
+    Args:
+        namespace_yamls: list of NamespaceYAML objects
+
+    """
+    yaml = YAML()
+    yaml.explicit_start = False
+    yaml.indent(mapping=MAPPING, sequence=SEQUENCE, offset=OFFSET)
+    for idx, namespace in enumerate(namespace_yamls):
+        if idx != 0 and not yaml.explicit_start:
+            yaml.explicit_start = True
+        yaml.dump(vars(namespace), outfile)

--- a/tests/test_hld.py
+++ b/tests/test_hld.py
@@ -38,6 +38,7 @@ class Test_HLD_Generator():
                                    return_value=tst_repo_components)
         mock_get_matches = mocker.patch(f'{self.CLASS}._get_matches')
         mock_gen_HLD = mocker.patch(f'{self.CLASS}._generate_HLD')
+        mock_gen_manifests = mocker.patch(f'{self.CLASS}._generate_manifests')
 
         # Call function
         tst_hld_generator.generate()
@@ -47,6 +48,7 @@ class Test_HLD_Generator():
         mock_get_cd.assert_called_once()
         mock_get_matches.assert_called_once()
         mock_gen_HLD.assert_called_once()
+        mock_gen_manifests.assert_called_once()
 
     def test_get_cluster_components(self, mocker):
         """Test the _get_cluster_components method."""

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,83 @@
+"""Test the manifest.py file."""
+from io import StringIO
+
+from hydrate.manifest import NamespaceYAML
+from hydrate.manifest import generate_manifests
+from hydrate.manifest import _make_directory
+from hydrate.manifest import _create_namespaces_data
+from hydrate.manifest import _generate_namespaces_yaml
+
+
+def test_NamespaceYAML():
+    """Test the NamespaceYAML class."""
+    tst_data = NamespaceYAML("Test Namespace")
+    assert tst_data.apiVersion == "v1"
+    assert tst_data.kind == "Namespace"
+    assert tst_data.metadata["name"] == "Test Namespace"
+
+
+def test_generate_manifests(mocker):
+    """Test the generate_manifests function."""
+    tst_namespaces = ["test1", "test2", "test3"]
+    mock_make_directory = mocker.patch("hydrate.manifest._make_directory")
+    mock_create_namespaces_data = mocker.patch(
+        "hydrate.manifest._create_namespaces_data")
+    mock_generate_namespaces_yaml = mocker.patch(
+        "hydrate.manifest._generate_namespaces_yaml")
+
+    generate_manifests(namespaces=tst_namespaces)
+
+    mock_make_directory.assert_called_with("manifests")
+    mock_create_namespaces_data.assert_called_with(tst_namespaces)
+    mock_generate_namespaces_yaml.assert_called_once()
+
+
+def test_make_directory(mocker):
+    """Test the _make_directory function."""
+    mock_os_makedirs = mocker.patch("hydrate.manifest.os.makedirs")
+    tst_path = "tst-manifests"
+
+    _make_directory(tst_path)
+
+    mock_os_makedirs.assert_called_with(tst_path, exist_ok=True)
+
+
+def test_create_namespaces_data():
+    """Test the _create_namespaces_data function."""
+    tst_data = ["test1", "test2", "test3"]
+    exp_return = [NamespaceYAML("test1"),
+                  NamespaceYAML("test2"),
+                  NamespaceYAML("test3")]
+
+    tst_return = _create_namespaces_data(tst_data)
+
+    for tst_obj, exp_obj in zip(tst_return, exp_return):
+        assert tst_obj == exp_obj
+
+
+def test_generate_namespaces_yaml():
+    """Test the _generate_namespaces_yaml function."""
+    tst_data = [NamespaceYAML("test1"),
+                NamespaceYAML("test2"),
+                NamespaceYAML("test3")]
+    tst_outfile = StringIO()
+    exp_outfile = """apiVersion: v1
+kind: Namespace
+metadata:
+  name: test1
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test3
+"""
+
+    _generate_namespaces_yaml(tst_data, tst_outfile)
+
+    tst_outfile.seek(0)
+    assert tst_outfile.read() == exp_outfile

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -26,6 +26,8 @@ def test_generate_manifests(mocker, dry_run):
         "hydrate.manifest._create_namespaces_data")
     mock_generate_namespaces_yaml = mocker.patch(
         "hydrate.manifest._generate_namespaces_yaml")
+    mock_ospath_join = mocker.patch(
+        "hydrate.manifest.os.path.join")
 
     generate_manifests(namespaces=tst_namespaces, dry_run=dry_run)
 
@@ -33,6 +35,7 @@ def test_generate_manifests(mocker, dry_run):
     mock_generate_namespaces_yaml.assert_called_once()
     if not dry_run:
         mock_make_directory.assert_called_with("manifests")
+        mock_ospath_join.assert_called_once()
 
 
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,5 +1,6 @@
 """Test the manifest.py file."""
 from io import StringIO
+import pytest
 
 from hydrate.manifest import NamespaceYAML
 from hydrate.manifest import generate_manifests
@@ -15,8 +16,9 @@ def test_NamespaceYAML():
     assert tst_data.kind == "Namespace"
     assert tst_data.metadata["name"] == "Test Namespace"
 
-
-def test_generate_manifests(mocker):
+tst_dry_run = [True, False]
+@pytest.mark.parametrize('dry_run', tst_dry_run)
+def test_generate_manifests(mocker, dry_run):
     """Test the generate_manifests function."""
     tst_namespaces = ["test1", "test2", "test3"]
     mock_make_directory = mocker.patch("hydrate.manifest._make_directory")
@@ -25,11 +27,13 @@ def test_generate_manifests(mocker):
     mock_generate_namespaces_yaml = mocker.patch(
         "hydrate.manifest._generate_namespaces_yaml")
 
-    generate_manifests(namespaces=tst_namespaces)
+    generate_manifests(namespaces=tst_namespaces, dry_run=dry_run)
 
-    mock_make_directory.assert_called_with("manifests")
     mock_create_namespaces_data.assert_called_with(tst_namespaces)
     mock_generate_namespaces_yaml.assert_called_once()
+    if not dry_run:
+        mock_make_directory.assert_called_with("manifests")
+
 
 
 def test_make_directory(mocker):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -9,6 +9,8 @@ from hydrate.manifest import _create_namespaces_data
 from hydrate.manifest import _generate_namespaces_yaml
 
 
+MODULE = "hydrate.manifest"
+
 def test_NamespaceYAML():
     """Test the NamespaceYAML class."""
     tst_data = NamespaceYAML("Test Namespace")
@@ -23,11 +25,12 @@ def test_generate_manifests(mocker, dry_run):
     tst_namespaces = ["test1", "test2", "test3"]
     mock_make_directory = mocker.patch("hydrate.manifest._make_directory")
     mock_create_namespaces_data = mocker.patch(
-        "hydrate.manifest._create_namespaces_data")
+        f"{MODULE}._create_namespaces_data")
     mock_generate_namespaces_yaml = mocker.patch(
-        "hydrate.manifest._generate_namespaces_yaml")
-    mock_ospath_join = mocker.patch(
-        "hydrate.manifest.os.path.join")
+        f"{MODULE}._generate_namespaces_yaml")
+    mock_open = mocker.patch(
+        f"builtins.open",
+        mocker.mock_open(read_data="test-data"))
 
     generate_manifests(namespaces=tst_namespaces, dry_run=dry_run)
 
@@ -35,7 +38,7 @@ def test_generate_manifests(mocker, dry_run):
     mock_generate_namespaces_yaml.assert_called_once()
     if not dry_run:
         mock_make_directory.assert_called_with("manifests")
-        mock_ospath_join.assert_called_once()
+        mock_open.assert_called_once()
 
 
 


### PR DESCRIPTION
This PR adds manifest.py, where the manifests directory is created and populated with a namespaces.yaml file containing all the namespaces found on the cluster.

When the dry_run argument is set, the namespaces.yaml file is printed to the terminal.