### PR TITLE
Remove default namespaces from manifest namespaces.yaml generation

### DIFF
--- a/hydrate/cluster.py
+++ b/hydrate/cluster.py
@@ -37,7 +37,7 @@ class Cluster():
         components = []
         default_deployments = self.get_namespaced_deployments("default")
         namespaces = self.get_namespaces()
-        namespaces = self.remove_defaults(namespaces)
+        namespaces = remove_default_namespaces(namespaces)
         # Scenario where cluster applications live in namespaces
         if namespaces:
             first_words = [get_first_word(name) for name in namespaces]
@@ -112,19 +112,20 @@ class Cluster():
         comp_list = [Component(component[0]) for component in comp_list]
         return comp_list
 
-    def remove_defaults(self, namespaces):
-        """Remove the default and kubernetes namespaces.
 
-        Returns:
-            ret_list: list of namespaces
+def remove_default_namespaces(namespaces):
+    """Remove the default and kubernetes namespaces.
 
-        """
-        ret_list = []
-        ignore_set = {"default", "kube-public", "kube-system"}
-        for namespace in namespaces:
-            if namespace not in ignore_set:
-                ret_list.append(namespace)
-        return ret_list
+    Returns:
+        ret_list: list of namespaces
+
+    """
+    ret_list = []
+    ignore_set = {"default", "kube-public", "kube-system"}
+    for namespace in namespaces:
+        if namespace not in ignore_set:
+            ret_list.append(namespace)
+    return ret_list
 
 
 def get_first_word(string, delimiter="-"):

--- a/hydrate/manifest.py
+++ b/hydrate/manifest.py
@@ -3,6 +3,7 @@
 import os
 from io import StringIO
 from ruamel.yaml import YAML
+from .cluster import remove_default_namespaces
 
 MAPPING = 2
 SEQUENCE = 4
@@ -41,6 +42,7 @@ def generate_manifests(namespaces=None, directory="manifests", dry_run=False):
 
     """
     if namespaces:
+        namespaces = remove_default_namespaces(namespaces)
         data = _create_namespaces_data(namespaces)
         if not dry_run:
             _make_directory(directory)

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -3,6 +3,7 @@ import pytest
 
 from hydrate.component import Component
 from hydrate.cluster import Cluster
+from hydrate.cluster import remove_default_namespaces
 from hydrate.cluster import get_first_word
 from hydrate.cluster import count_first_word
 from hydrate.cluster import sort_dict_by_value
@@ -57,7 +58,7 @@ class TestCluster():
             "hydrate.cluster.Cluster.get_namespaces",
             return_value=tst_namespaces)
         mock_remove_defaults = mocker.patch(
-            "hydrate.cluster.Cluster.remove_defaults",
+            "hydrate.cluster.remove_default_namespaces",
             return_value=tst_namespaces)
         mock_get_first_word = mocker.patch("hydrate.cluster.get_first_word")
         mock_get_namespaced_deployments = mocker.patch(
@@ -141,11 +142,10 @@ class TestCluster():
     @pytest.mark.parametrize("tst_namespaces, exp_namespaces",
                              [(tst_remove_defaults1, exp_remove_defaults1),
                               (tst_remove_defaults2, exp_remove_defaults2)])
-    def test_remove_defaults(self, cluster_connection,
-                             tst_namespaces, exp_namespaces):
-        """Test Cluster.remove_defaults function."""
-        mock_cluster = cluster_connection
-        assert mock_cluster.remove_defaults(tst_namespaces) == exp_namespaces
+    def test_remove_default_namespaces(self, cluster_connection,
+                                       tst_namespaces, exp_namespaces):
+        """Test remove_default_namespaces function."""
+        assert remove_default_namespaces(tst_namespaces) == exp_namespaces
 
 
 tst_string = "fabrikate-elasticsearch"


### PR DESCRIPTION
closes #33 

This PR removes the default namespaces from the namespaces.yaml generation. 
Through a small refactor, I'm reusing a function that I already wrote to accomplish this.