### PR TITLE
Default output location is now an /out folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ apikey
 kubeconfig*
 tmp
 __pycache__
+/out
+/manifests

--- a/hydrate/__main__.py
+++ b/hydrate/__main__.py
@@ -41,7 +41,7 @@ def parse_args(args):
     parser.add_argument(
         '-o', '--output',
         action='store',
-        default=os.getcwd(),
+        default='',
         help='Output path for the generated component.yaml.',
         metavar='PATH')
     parser.add_argument(

--- a/hydrate/hld.py
+++ b/hydrate/hld.py
@@ -82,10 +82,11 @@ class HLD_Generator():
                 verbose_print("Writing component.yaml to {}".format(self.output))
                 output_file = os.path.join(self.output, "component.yaml")
             else:
-                # File Written just outside the hydrate directory?
-                path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+                # Default: file written to an /out folder outside of the hydrate module
+                path = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "out")
+                os.makedirs(path, exist_ok =True)
                 verbose_print("Writing component.yaml to {}".format(path))
-                output_file = "component.yaml"
+                output_file = os.path.join(path, "component.yaml")
             with open(output_file, 'w') as of:
                 self.dump_yaml(data, of)
 


### PR DESCRIPTION
Closes #41 

Changed the default arg value for output to an empty string. Upon writing the `component.yaml` file, if the output location is still an empty string, Hydrate will create an `/out` directory outside of the `hydrate` module and write the file there. When running on Docker, this will make copying the file from the container a lot easier.

Previously, the `else` condition in `hld.py` was never satisfied since the default arg was set to the current working directory.